### PR TITLE
Improving JSON parsing performance during validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,19 @@ dependencies = [
     "alembic",
     "python-json-logger",
     "async_lru",
-    "greenlet>=3.2.1"
+    "greenlet>=3.2.1",
+    "orjson>=3.10.18",
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest_asyncio", "pytest-mock", "httpx", "flake8", "pytest-aiohttp"]
+test = [
+    "pytest",
+    "pytest_asyncio",
+    "pytest-mock",
+    "httpx",
+    "flake8",
+    "pytest-aiohttp",
+]
 
 [build-system]
 requires = ["setuptools>=57", "wheel", "setuptools-scm"]
@@ -26,7 +34,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope="function"
+asyncio_default_fixture_loop_scope = "function"
 addopts = "--capture=no"
 log_cli = false
 #log_cli_level = "DEBUG"

--- a/src/patrol/validation/validator.py
+++ b/src/patrol/validation/validator.py
@@ -4,6 +4,7 @@ from typing import Callable, Tuple, Any
 
 import uuid
 import bittensor as bt
+import orjson
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from patrol.chain_data.event_collector import EventCollector
@@ -168,7 +169,7 @@ class Validator:
                     raise Exception("Bad response status %s", response.status)
 
                 response_time = time.perf_counter() - timings["request_start"]
-                json_response = json.loads(buffer.decode('utf-8'))
+                json_response = orjson.loads(buffer.decode('utf-8'))
 
                 return json_response, response_time
 


### PR DESCRIPTION
In the [_invoke_miner ](https://github.com/tao-dot-com/patrol_subnet/blob/8e8ebb4638e739e0972e22c8ecf9e05912241681/src/patrol/validation/validator.py#L171)method, the miner's response time is measured, and only after that the graph is parsed. Since the graph is large, parsing consumes a lot of CPU resources, which blocks all other coroutines. This also affects coroutines that are waiting for the miner's response. Overall, this is a significant issue that impacts the accuracy of measuring the miners' response time. While the real solution involves more than just replacing json with orjson, the switch is something that can be done quickly and without any refactoring.